### PR TITLE
[4] Refactoring Gold Achievement

### DIFF
--- a/Dungeoneer/assets/data/achievements.dat
+++ b/Dungeoneer/assets/data/achievements.dat
@@ -135,6 +135,18 @@
                 "value": 400,
                 "playerNeedsToBeAlive": true
             }
+        },
+        {
+            "class": "com.interrupt.dungeoneer.achievements.Achievement",
+            "identifier": "RUN_GOLD",
+            "title": "achievement.goldTaken.title",
+            "description": "achievement.goldTaken.description",
+            "trigger": {
+                "class": "com.interrupt.dungeoneer.achievements.AchievementTrigger",
+                "triggerType": "GOLD_TAKEN",
+                "conditionType": "GREATER",
+                "value": 300
+            }
         }
     ]
 }

--- a/Dungeoneer/src/com/interrupt/dungeoneer/achievements/AchievementTriggerType.java
+++ b/Dungeoneer/src/com/interrupt/dungeoneer/achievements/AchievementTriggerType.java
@@ -12,4 +12,5 @@ public enum AchievementTriggerType {
     TELEPORTED,
     TRAP_ACTIVATED,
     WAND_USED,
+    GOLD_TAKEN,
 }

--- a/Dungeoneer/src/com/interrupt/dungeoneer/entities/Player.java
+++ b/Dungeoneer/src/com/interrupt/dungeoneer/entities/Player.java
@@ -2577,4 +2577,9 @@ public class Player extends Actor {
 				itm.drawable.refresh();
 		}
     }
+
+    public void addGold(int amount) {
+        gold += amount;
+        history.tookGold(amount);
+    }
 }

--- a/Dungeoneer/src/com/interrupt/dungeoneer/entities/items/Gold.java
+++ b/Dungeoneer/src/com/interrupt/dungeoneer/entities/items/Gold.java
@@ -1,6 +1,5 @@
 package com.interrupt.dungeoneer.entities.items;
 
-import com.badlogic.gdx.math.Vector3;
 import com.interrupt.dungeoneer.Audio;
 import com.interrupt.dungeoneer.annotations.EditorProperty;
 import com.interrupt.dungeoneer.entities.Item;
@@ -12,7 +11,7 @@ import com.interrupt.managers.StringManager;
 import java.text.MessageFormat;
 
 public class Gold extends Item {
-	
+
 	public Gold() {
 		tex = 88;
 		artType = ArtType.item;
@@ -22,18 +21,18 @@ public class Gold extends Item {
 		collision.x = 0.1f;
 		collision.y = 0.1f;
 	}
-	
+
 	@EditorProperty
 	public int goldAmount = 1;
-	
+
 	public boolean autoPickup = false;
-	
+
 	public boolean playedDropSound = false;
 
 	public Gold(float x, float y) {
 		super(x, y, 0, ItemType.gold, StringManager.get("items.Gold.defaultNameText"));
 	}
-	
+
 	public Gold(int amount) {
 		this();
 		goldAmount = amount;
@@ -41,7 +40,7 @@ public class Gold extends Item {
 
 		if(goldAmount <= 0) goldAmount = 1;
 		if(goldAmount > 5) tex = 89;
-		
+
 		pickupSound = "pu_gold.mp3";
 	}
 
@@ -49,24 +48,24 @@ public class Gold extends Item {
 	public String GetItemText() {
 		return MessageFormat.format(StringManager.get("items.Gold.goldItemText"), this.goldAmount);
 	}
-	
+
 	@Override
 	public void tick(Level level, float delta)
 	{
 		super.tick(level, delta);
-		
+
 		if(isActive && autoPickup) {
 			Player p = Game.instance.player;
 			if(Math.abs(p.x + 0.5f - x) < 0.3f && Math.abs(p.y + 0.5f - y ) < 0.3f) {
-				p.gold++;
+                p.addGold(1);
 				isActive = false;
 			}
 		}
 	}
-	
+
 	protected void pickup(Player player) {
 		if(isActive) {
-			player.gold += goldAmount;
+            player.addGold(goldAmount);
 			isActive = false;
 			Audio.playSound(pickupSound, 0.3f, 1f);
 			makeItemPickupAnimation(player);

--- a/Dungeoneer/src/com/interrupt/dungeoneer/game/Progression.java
+++ b/Dungeoneer/src/com/interrupt/dungeoneer/game/Progression.java
@@ -1,9 +1,7 @@
 package com.interrupt.dungeoneer.game;
 
-import com.badlogic.gdx.files.FileHandle;
 import com.badlogic.gdx.utils.Array;
 import com.badlogic.gdx.utils.ArrayMap;
-import com.interrupt.api.steam.workshop.WorkshopModData;
 import com.interrupt.dungeoneer.entities.Item;
 
 import java.util.HashMap;
@@ -15,6 +13,7 @@ public class Progression {
 	public int messagesFound = 0;
 	public boolean won = false;
 
+    /** @deprecated */
 	public int goldAtStartOfRun = 0;
 
     public int wins = 0;
@@ -47,7 +46,6 @@ public class Progression {
 		dungeonAreasSeen.clear();
 		uniqueItemsSpawned.clear();
 		untilDeathProgressionTriggers.clear();
-		goldAtStartOfRun = gold;
 	}
 
 	public void trackMods() {

--- a/Dungeoneer/src/com/interrupt/dungeoneer/screens/GameOverScreen.java
+++ b/Dungeoneer/src/com/interrupt/dungeoneer/screens/GameOverScreen.java
@@ -300,11 +300,6 @@ public class GameOverScreen extends StatsScreen {
         else {
             Game.achievementManager.achievementDealer.achieve("WON");
         }
-
-        int goldThisRun = Game.instance.player.gold - Game.instance.progression.goldAtStartOfRun;
-        if(goldThisRun > 300) {
-            Game.achievementManager.achievementDealer.achieve("RUN_GOLD");
-        }
     }
 
     public void startGameOver() {

--- a/Dungeoneer/src/com/interrupt/dungeoneer/screens/StatsScreen.java
+++ b/Dungeoneer/src/com/interrupt/dungeoneer/screens/StatsScreen.java
@@ -16,19 +16,17 @@ public class StatsScreen extends BaseScreen {
     public StatsScreen() { }
 
     Color statLabelColor = new Color(0.6f, 0, 0, 1);
-	
+
 	public void makeStats(Integer progress, boolean doFade) {
 		ui.clear();
-		
+
 		// display some stats
 		Table mainTable = new Table();
 		mainTable.setFillParent(true);
 
-		int goldThisRun = Game.instance.player.gold - Game.instance.progression.goldAtStartOfRun;
-		
 		Table innerTable = new Table();
 		if(progress > 0) makeStat(innerTable, StringManager.get("screens.GameOverScreen.playtimeStatLabel"), Game.instance.player.getPlaytime(), doFade);
-		if(progress > 1) makeStat(innerTable, StringManager.get("screens.GameOverScreen.goldStatLabel"), goldThisRun, doFade);
+		if(progress > 1) makeStat(innerTable, StringManager.get("screens.GameOverScreen.goldStatLabel"), Game.instance.player.history.goldTaken, doFade);
 		if(progress > 2) makeStat(innerTable, StringManager.get("screens.GameOverScreen.killsStatLabel"), Game.instance.player.history.monstersKilled, doFade);
 		if(progress > 3) makeStat(innerTable, StringManager.get("screens.GameOverScreen.damageStatLabel"), Game.instance.player.history.damageTaken, doFade);
 		if(progress > 4) makeStat(innerTable, StringManager.get("screens.GameOverScreen.potionsStatLabel"), Game.instance.player.history.potionsDrank, doFade);
@@ -36,7 +34,7 @@ public class StatsScreen extends BaseScreen {
 		if(progress > 6) makeStat(innerTable, StringManager.get("screens.GameOverScreen.scrollsStatLabel"), Game.instance.player.history.scrollsUsed, doFade);
 		if(progress > 7) makeStat(innerTable, StringManager.get("screens.GameOverScreen.trapsStatLabel"), Game.instance.player.history.trapsActivated, doFade);
         if(progress > 8) makeStat(innerTable, StringManager.get("screens.GameOverScreen.secretsStatLabel"), Game.instance.player.history.secretsFound, doFade);
-		
+
 		mainTable.add(innerTable);
 		ui.addActor(mainTable);
         ui.act(0.0001f);

--- a/Dungeoneer/src/com/interrupt/helpers/PlayerHistory.java
+++ b/Dungeoneer/src/com/interrupt/helpers/PlayerHistory.java
@@ -20,6 +20,7 @@ public class PlayerHistory {
 	public int timesPoisoned = 0;
 	public int thingsIdentified = 0;
 	public int secretsFound = 0;
+	public int goldTaken = 0;
 
 	public PlayerHistory() { }
 
@@ -120,6 +121,15 @@ public class PlayerHistory {
 
 		Game.achievementManager.triggerAchievement(
             new AchievementTriggerEvent(AchievementTriggerType.SECRET_FOUND, secretsFound)
+        );
+	}
+
+	public void tookGold(int amount) {
+		Gdx.app.log("PlayerHistory", "Took gold");
+		goldTaken += amount;
+
+		Game.achievementManager.triggerAchievement(
+            new AchievementTriggerEvent(AchievementTriggerType.GOLD_TAKEN, goldTaken)
         );
 	}
 }


### PR DESCRIPTION
This actually might fix https://github.com/Interrupt/delverengine/issues/238.

Moves the `goldAtStartOfRun` into `PlayerHistory` where it makes more sense?

Whenever we take gold, we count towards the achievement. So it can be earned whenever we have enough, not only at the end game screen.

⚠️ Only thing here is, that `goldAtStartOfRun` was removed from `Progression`, so active saves/runs start with essentially less gold. The achievement would only be fixed upon starting a new run.