### PR TITLE
Refactoring Bag Upgrade Achievement Logic

### DIFF
--- a/Dungeoneer/assets/data/achievements.dat
+++ b/Dungeoneer/assets/data/achievements.dat
@@ -147,6 +147,30 @@
                 "conditionType": "GREATER",
                 "value": 300
             }
+        },
+        {
+            "class": "com.interrupt.dungeoneer.achievements.Achievement",
+            "identifier": "SQUID3",
+            "title": "achievement.inventorySlotAdded.title",
+            "description": "achievement.inventorySlotAdded.description",
+            "trigger": {
+                "class": "com.interrupt.dungeoneer.achievements.AchievementTrigger",
+                "triggerType": "INVENTORY_SLOT_ADDED",
+                "conditionType": "GREATER_EQUAL",
+                "value": 17
+            }
+        },
+        {
+            "class": "com.interrupt.dungeoneer.achievements.Achievement",
+            "identifier": "SQUID4",
+            "title": "achievement.hotbarSlotAdded.title",
+            "description": "achievement.hotbarSlotAdded.description",
+            "trigger": {
+                "class": "com.interrupt.dungeoneer.achievements.AchievementTrigger",
+                "triggerType": "HOTBAR_SLOT_ADDED",
+                "conditionType": "GREATER_EQUAL",
+                "value": 4
+            }
         }
     ]
 }

--- a/Dungeoneer/src/com/interrupt/dungeoneer/achievements/AchievementTriggerType.java
+++ b/Dungeoneer/src/com/interrupt/dungeoneer/achievements/AchievementTriggerType.java
@@ -13,4 +13,6 @@ public enum AchievementTriggerType {
     TRAP_ACTIVATED,
     WAND_USED,
     GOLD_TAKEN,
+    INVENTORY_SLOT_ADDED,
+    HOTBAR_SLOT_ADDED,
 }

--- a/Dungeoneer/src/com/interrupt/dungeoneer/entities/Player.java
+++ b/Dungeoneer/src/com/interrupt/dungeoneer/entities/Player.java
@@ -275,9 +275,7 @@ public class Player extends Actor {
 			Game.hudManager.backpack.refresh();
 			Game.hudManager.quickSlots.refresh();
 
-			if(inventorySize - hotbarSize >= 35) {
-				Game.achievementManager.achievementDealer.achieve("SQUID3");
-			}
+			Game.instance.player.history.addedInventorySlot();
 		}
 	}
 
@@ -293,9 +291,7 @@ public class Player extends Actor {
 			Game.hudManager.backpack.refresh();
 			Game.hudManager.quickSlots.refresh();
 
-			if(hotbarSize >= 9) {
-				Game.achievementManager.achievementDealer.achieve("SQUID4");
-			}
+			Game.instance.player.history.addedHotbarSlot();
 		}
 	}
 

--- a/Dungeoneer/src/com/interrupt/helpers/PlayerHistory.java
+++ b/Dungeoneer/src/com/interrupt/helpers/PlayerHistory.java
@@ -21,6 +21,8 @@ public class PlayerHistory {
 	public int thingsIdentified = 0;
 	public int secretsFound = 0;
 	public int goldTaken = 0;
+    public int inventorySlotsAdded = 0;
+    public int hotbarSlotsAdded = 0;
 
 	public PlayerHistory() { }
 
@@ -130,6 +132,24 @@ public class PlayerHistory {
 
 		Game.achievementManager.triggerAchievement(
             new AchievementTriggerEvent(AchievementTriggerType.GOLD_TAKEN, goldTaken)
+        );
+	}
+
+    public void addedInventorySlot() {
+		Gdx.app.log("PlayerHistory", "Added inventory slot");
+		inventorySlotsAdded++;
+
+		Game.achievementManager.triggerAchievement(
+            new AchievementTriggerEvent(AchievementTriggerType.INVENTORY_SLOT_ADDED, inventorySlotsAdded)
+        );
+	}
+
+    public void addedHotbarSlot() {
+		Gdx.app.log("PlayerHistory", "Added hotbar slot");
+		hotbarSlotsAdded++;
+
+		Game.achievementManager.triggerAchievement(
+            new AchievementTriggerEvent(AchievementTriggerType.HOTBAR_SLOT_ADDED, hotbarSlotsAdded)
         );
 	}
 }


### PR DESCRIPTION
Moved the bag upgrade achievements to the config file.

We are now using the exact amount of upgrades (17 and 4). ⚠️ This assumes bag upgrades are NOT persisted and only valid for a single run. This is how I read the `items.dat` file.